### PR TITLE
Audit memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,10 @@ group :development do
   gem "get_process_mem"
 
   gem "prometheus-client"
+
+  # benchmarks
+  gem "benchmark-ips"
+  gem "benchmark-memory"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     bcrypt (3.1.20)
     benchmark (0.3.0)
     benchmark-ips (2.13.0)
+    benchmark-memory (0.2.0)
+      memory_profiler (~> 1)
     better_html (2.0.2)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -671,6 +673,8 @@ DEPENDENCIES
   avo-record_link_field
   awesome_print
   aws-sdk-s3
+  benchmark-ips
+  benchmark-memory
   bootsnap (>= 1.4.2)
   bump
   bundler-integrity (~> 1.0)

--- a/benchmark/base_field_benchmark.rb
+++ b/benchmark/base_field_benchmark.rb
@@ -1,0 +1,42 @@
+require "benchmark"
+require "benchmark/ips"
+require_relative "../spec/dummy/config/environment"
+
+@fields = (1..24).map { Avo::Fields::TextField.new("foo") }
+
+def get_types
+  ENV["MEMOIZE_TYPE"] = nil
+  @fields.each(&:type)
+end
+
+def get_types_memoized
+  ENV["MEMOIZE_TYPE"] = "true"
+  @fields.each(&:type)
+end
+
+puts "BMBM"
+Benchmark.bmbm do |x|
+  x.report("type:         ") { get_types }
+  x.report("type_memoized:") { get_types_memoized }
+end
+
+puts "\n\n"
+
+puts "IPS"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("type:         ") { get_types }
+  x.report("type_memoized:") { get_types_memoized }
+
+  x.compare!
+end
+
+puts ""
+puts "MEMORY"
+Benchmark.memory do |x|
+  x.report("type:         ") { get_types }
+  x.report("type_memoized:") { get_types_memoized }
+
+  x.compare!
+end

--- a/benchmark/file_hash_benchmark.rb
+++ b/benchmark/file_hash_benchmark.rb
@@ -7,18 +7,27 @@ require_relative "../spec/dummy/config/environment"
 
 def calculate_file_hashes
   ENV["CACHE_FILE_HASH"] = nil
+  ENV["MEMOIZE_RESOURCE_FILE_NAME"] = nil
   @resources.each(&:file_hash)
 end
 
 def calculate_file_hashes_cached
   ENV["CACHE_FILE_HASH"] = "true"
+  ENV["MEMOIZE_RESOURCE_FILE_NAME"] = nil
+  @resources.each(&:file_hash)
+end
+
+def calculate_file_hashes_cached_memoized
+  ENV["CACHE_FILE_HASH"] = "true"
+  ENV["MEMOIZE_RESOURCE_FILE_NAME"] = "true"
   @resources.each(&:file_hash)
 end
 
 puts "BMBM"
 Benchmark.bmbm do |x|
-  x.report("file_hash:       ") { calculate_file_hashes }
-  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+  x.report("file_hash:                ") { calculate_file_hashes }
+  x.report("file_hash_cached:         ") { calculate_file_hashes_cached }
+  x.report("file_hash_cached_memoized:") { calculate_file_hashes_cached_memoized }
 end
 
 puts "\n\n"
@@ -27,8 +36,9 @@ puts "IPS"
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report("file_hash:       ") { calculate_file_hashes }
-  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+  x.report("file_hash:                ") { calculate_file_hashes }
+  x.report("file_hash_cached:         ") { calculate_file_hashes_cached }
+  x.report("file_hash_cached_memoized:") { calculate_file_hashes_cached_memoized }
 
   x.compare!
 end
@@ -36,8 +46,9 @@ end
 puts ""
 puts "MEMORY"
 Benchmark.memory do |x|
-  x.report("file_hash:       ") { calculate_file_hashes }
-  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+  x.report("file_hash:                ") { calculate_file_hashes }
+  x.report("file_hash_cached:         ") { calculate_file_hashes_cached }
+  x.report("file_hash_cached_memoized:") { calculate_file_hashes_cached_memoized }
 
   x.compare!
 end

--- a/benchmark/file_hash_benchmark.rb
+++ b/benchmark/file_hash_benchmark.rb
@@ -1,0 +1,43 @@
+require "benchmark"
+require "benchmark/ips"
+require_relative "../spec/dummy/config/environment"
+
+# @resources = (1..24).map { Avo::Resources::Post.new }
+@resources = (1..24).map { Avo::Resources::User.new }
+
+def calculate_file_hashes
+  ENV["CACHE_FILE_HASH"] = nil
+  @resources.each(&:file_hash)
+end
+
+def calculate_file_hashes_cached
+  ENV["CACHE_FILE_HASH"] = "true"
+  @resources.each(&:file_hash)
+end
+
+puts "BMBM"
+Benchmark.bmbm do |x|
+  x.report("file_hash:       ") { calculate_file_hashes }
+  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+end
+
+puts "\n\n"
+
+puts "IPS"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("file_hash:       ") { calculate_file_hashes }
+  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+
+  x.compare!
+end
+
+puts ""
+puts "MEMORY"
+Benchmark.memory do |x|
+  x.report("file_hash:       ") { calculate_file_hashes }
+  x.report("file_hash_cached:") { calculate_file_hashes_cached }
+
+  x.compare!
+end

--- a/benchmark/resource_class_name_benchmark.rb
+++ b/benchmark/resource_class_name_benchmark.rb
@@ -1,0 +1,48 @@
+require "benchmark"
+require "benchmark/ips"
+require_relative "../spec/dummy/config/environment"
+
+@resources = (1..24).map { Avo::Resources::User.new }
+
+def call_class_name
+  ENV["MEMOIZE_RESOURCE_CLASS_NAME"] = nil
+  @resources.each(&:model_class)
+  @resources.each(&:model_key)
+  @resources.each(&:translation_key)
+  @resources.each(&:name)
+end
+
+def call_class_name_memoized
+  ENV["MEMOIZE_RESOURCE_CLASS_NAME"] = "true"
+  @resources.each(&:model_class)
+  @resources.each(&:model_key)
+  @resources.each(&:translation_key)
+  @resources.each(&:name)
+end
+
+puts "BMBM"
+Benchmark.bmbm do |x|
+  x.report("class_name:                ") { call_class_name }
+  x.report("class_name_memoized:       ") { call_class_name_memoized }
+end
+
+puts "\n\n"
+
+puts "IPS"
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("class_name:                ") { call_class_name }
+  x.report("class_name_memoized:       ") { call_class_name_memoized }
+
+  x.compare!
+end
+
+puts ""
+puts "MEMORY"
+Benchmark.memory do |x|
+  x.report("class_name:                ") { call_class_name }
+  x.report("class_name_memoized:       ") { call_class_name_memoized }
+
+  x.compare!
+end

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -158,11 +158,19 @@ module Avo
       # With uncountable models route key appends an _index suffix (Fish->fish_index)
       # Example: User->users, MediaItem->media_items, Fish->fish
       def model_key
-        model_class.model_name.plural
+        if ENV["MEMOIZE_RESOURCE_CLASS_NAME"]
+          @model_key ||= model_class.model_name.plural
+        else
+          model_class.model_name.plural
+        end
       end
 
       def class_name
-        to_s.demodulize
+        if ENV["MEMOIZE_RESOURCE_CLASS_NAME"]
+          @class_name ||= to_s.demodulize
+        else
+          to_s.demodulize
+        end
       end
 
       def route_key
@@ -178,7 +186,11 @@ module Avo
       end
 
       def name
-        name_from_translation_key(count: 1, default: class_name.underscore.humanize)
+        if ENV["MEMOIZE_RESOURCE_CLASS_NAME"]
+          @name ||= name_from_translation_key(count: 1, default: class_name.underscore.humanize)
+        else
+          name_from_translation_key(count: 1, default: class_name.underscore.humanize)
+        end
       end
       alias_method :singular_name, :name
 

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -456,7 +456,6 @@ module Avo
     def file_hash
       content_to_be_hashed = ""
 
-      file_name = self.class.underscore_name.tr(" ", "_")
       resource_path = Rails.root.join("app", "avo", "resources", "#{file_name}.rb").to_s
       if File.file? resource_path
         if ENV["CACHE_FILE_HASH"]
@@ -487,6 +486,14 @@ module Avo
       end
 
       result
+    end
+
+    def file_name
+      if ENV["MEMOIZE_RESOURCE_FILE_NAME"]
+        @file_name ||= self.class.underscore_name.tr(" ", "_")
+      else
+        self.class.underscore_name.tr(" ", "_")
+      end
     end
 
     # We will not overwrite any attributes that come pre-filled in the record.

--- a/lib/avo/base_resource.rb
+++ b/lib/avo/base_resource.rb
@@ -459,13 +459,21 @@ module Avo
       file_name = self.class.underscore_name.tr(" ", "_")
       resource_path = Rails.root.join("app", "avo", "resources", "#{file_name}.rb").to_s
       if File.file? resource_path
-        content_to_be_hashed += File.read(resource_path)
+        if ENV["CACHE_FILE_HASH"]
+          content_to_be_hashed += Avo::ResourceRegistry.instance.fetch(resource_path) { File.read(resource_path) }
+        else
+          content_to_be_hashed += File.read(resource_path)
+        end
       end
 
       # policy file hash
       policy_path = Rails.root.join("app", "policies", "#{file_name.gsub("_resource", "")}_policy.rb").to_s
       if File.file? policy_path
-        content_to_be_hashed += File.read(policy_path)
+        if ENV["CACHE_FILE_HASH"]
+          content_to_be_hashed += Avo::ResourceRegistry.instance.fetch(policy_path) { File.read(policy_path) }
+        else
+          content_to_be_hashed += File.read(policy_path)
+        end
       end
 
       Digest::MD5.hexdigest(content_to_be_hashed)

--- a/lib/avo/fields/base_field.rb
+++ b/lib/avo/fields/base_field.rb
@@ -243,7 +243,11 @@ module Avo
       end
 
       def type
-        self.class.name.demodulize.to_s.underscore.gsub("_field", "")
+        if ENV["MEMOIZE_TYPE"]
+          @type ||= self.class.name.demodulize.to_s.underscore.gsub("_field", "")
+        else
+          self.class.name.demodulize.to_s.underscore.gsub("_field", "")
+        end
       end
 
       def custom?

--- a/spec/dummy/config/initializers/avo_resource_registry.rb
+++ b/spec/dummy/config/initializers/avo_resource_registry.rb
@@ -1,0 +1,18 @@
+class Avo::ResourceRegistry
+  include Singleton
+
+  delegate_missing_to :@store
+
+  def initialize
+    super
+    @store = ActiveSupport::Cache::MemoryStore.new(size: 2.megabytes)
+  end
+
+  def []=(key, value)
+    @store.write(key, value)
+  end
+
+  def [](key)
+    @store.read(key)
+  end
+end


### PR DESCRIPTION
> [!WARNING]
> This PR is intended for discussion and experimentation, not for direct merging.

> [!NOTE]
> Benchmarks were tested using `ENV` flags/conditionals, which themselves incur somewhat of a cost. Total savings are therefore expected to be even somewhat higher

In this PR, several optimizations to `BaseResource` and `BaseField` were tried and documented.

## BaseResource#class_name
A setup experimenting with memoizing `BaseResource'`'s `class_name` method was tried. Since class names (of Avo resources, for that matter) are not expected not change during a deploy, this is a somewhat safe candidate for memoization. It's also called in 4 different places inside `BaseResource` so could potentially have some impact. The benchmark demonstrates this by calling those methods.

Note: memoizing route_key led to wrong “fish” routes to be rendered, which is why it was excluded from this benchmark

```
IPS
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin22]
Warming up --------------------------------------
class_name:
                       386.000 i/100ms
class_name_memoized:
                         3.586k i/100ms
Calculating -------------------------------------
class_name:
                          4.272k (± 8.9%) i/s -     21.230k in   5.028409s
class_name_memoized:
                         33.785k (± 8.7%) i/s -    168.542k in   5.037308s

Comparison:
class_name_memoized:       :    33784.7 i/s
class_name:                :     4272.0 i/s - 7.91x  slower


MEMORY
Calculating -------------------------------------
class_name:
                       109.368k memsize (     0.000  retained)
                         1.274k objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
class_name_memoized:
                         8.760k memsize (    40.000  retained)
                       146.000  objects (     1.000  retained)
                         2.000  strings (     1.000  retained)

Comparison:
class_name_memoized:       :       8760 allocated
class_name:                :     109368 allocated - 12.48x more
```

## BaseResource#file_hash
It appears that in the `file_hash` method, the whole file contents of a resource were read in every time a hash was to be calculated. Since the contents of a file aren’t likely to change during a deploy, an `Avo::ResourceRegistry` wrapping a small `ActiveSupport::Cache::MemoryStore` of 2 MB was implemented, in order to hold the file contents for the lifetime of a worker.

The implementations were compared in a benchmark. Below, file_hash denotes the original method, file_hash_cached one with the optimization from above in place, and file_hash_cached_memoized one where the file_name variable was extracted to an accessor method and memoized:

```
IPS
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin22]
Warming up --------------------------------------
file_hash:
                        47.000 i/100ms
file_hash_cached:
                        40.000 i/100ms
file_hash_cached_memoized:
                        71.000 i/100ms
Calculating -------------------------------------
file_hash:
                        482.143 (± 7.7%) i/s -      2.397k in   5.018987s
file_hash_cached:
                        542.237 (± 1.3%) i/s -      2.720k in   5.017009s
file_hash_cached_memoized:
                        691.949 (±12.9%) i/s -      3.408k in   5.064151s

Comparison:
file_hash_cached_memoized::      691.9 i/s
file_hash_cached:         :      542.2 i/s - 1.28x  slower
file_hash:                :      482.1 i/s - 1.44x  slower


MEMORY
Calculating -------------------------------------
file_hash:
                       955.496k memsize (     0.000  retained)
                         8.452k objects (     0.000  retained)
                        38.000  strings (     0.000  retained)
file_hash_cached:
                       786.256k memsize (   600.000  retained)
                         8.883k objects (    11.000  retained)
                        42.000  strings (    11.000  retained)
file_hash_cached_memoized:
                       582.776k memsize (     1.280k retained)
                         6.532k objects (    18.000  retained)
                        37.000  strings (    14.000  retained)

Comparison:
file_hash_cached_memoized::     582776 allocated
file_hash_cached:         :     786256 allocated - 1.35x more
file_hash:                :     955496 allocated - 1.64x more
```

## BaseField#type
is yet another candidate for memoization, because it simply wraps `self.class.name`:

```rb
def type
  @type ||= self.class.name.demodulize.to_s.underscore.gsub("_field", "")
end
```

Being called quite frequently, this should also produce some nice improvements:

```
IPS
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin22]
Warming up --------------------------------------
      type:              1.895k i/100ms
      type_memoized:    13.946k i/100ms
Calculating -------------------------------------
      type:              18.353k (± 3.5%) i/s -     92.855k in   5.065862s
      type_memoized:    135.575k (± 6.7%) i/s -    683.354k in   5.069222s

Comparison:
      type_memoized::   135574.9 i/s
      type:         :    18352.7 i/s - 7.39x  slower


MEMORY
Calculating -------------------------------------
      type:             29.648k memsize (     0.000  retained)
                       386.000  objects (     0.000  retained)
                         8.000  strings (     0.000  retained)
      type_memoized:     2.000k memsize (    40.000  retained)
                        50.000  objects (     1.000  retained)
                         2.000  strings (     1.000  retained)

Comparison:
      type_memoized::       2000 allocated
      type:         :      29648 allocated - 14.82x more
```